### PR TITLE
Add /beta command confirmation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ hs_err_pid*
 target/
 
 \.idea/
+.project
+.classpath
+.settings

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>com.destroystokyo.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.13.2-R0.1-SNAPSHOT</version>
+            <version>1.16.5-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.karlofduty</groupId>
     <artifactId>EMCTools</artifactId>
-    <version>1.1.7</version>
+    <version>1.2.0</version>
 
     <repositories>
         <repository>
@@ -34,8 +34,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/com/karlofduty/EMCTools/EMCTools.java
+++ b/src/main/java/com/karlofduty/EMCTools/EMCTools.java
@@ -10,9 +10,6 @@ import com.karlofduty.EMCTools.commands.JoinQueueCommand;
 import com.karlofduty.EMCTools.commands.PremiumCommand;
 
 import org.bukkit.Bukkit;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandExecutor;
-import org.bukkit.command.CommandSender;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import net.md_5.bungee.api.ChatColor;
@@ -31,7 +28,6 @@ public class EMCTools extends JavaPlugin
         this.getCommand("joinqueue").setExecutor(new JoinQueueCommand());
         this.getCommand("beta").setExecutor(new BetaCommand());
         this.getCommand("premium").setExecutor(new PremiumCommand());
-        this.getCommand("towny").setExecutor(new TownyCommand());
 
         Bukkit.getServer().getScheduler().scheduleSyncRepeatingTask(this, () ->
         {
@@ -45,13 +41,6 @@ public class EMCTools extends JavaPlugin
         }, 100, 100);
     }
 
-    private class TownyCommand implements CommandExecutor
-    {
-        public boolean onCommand(CommandSender sender, Command command, String label, String[] args)
-        {
-            return getServer().dispatchCommand(sender, "joinqueue towny");
-        }
-    }
     public static boolean executeCommand(String command)
     {
         return instance.getServer().dispatchCommand(instance.getServer().getConsoleSender(), command);

--- a/src/main/java/com/karlofduty/EMCTools/EMCTools.java
+++ b/src/main/java/com/karlofduty/EMCTools/EMCTools.java
@@ -1,15 +1,27 @@
 package com.karlofduty.EMCTools;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.Map.Entry;
+
+import com.karlofduty.EMCTools.commands.BetaCommand;
 import com.karlofduty.EMCTools.commands.JoinQueueCommand;
 import com.karlofduty.EMCTools.commands.PremiumCommand;
+
+import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.api.chat.TextComponent;
+
 public class EMCTools extends JavaPlugin
 {
     public static EMCTools instance;
+    public static Map<UUID, Long> awaitingBetaConfirmation = new HashMap<>();
 
     @Override
     public void onEnable()
@@ -18,28 +30,28 @@ public class EMCTools extends JavaPlugin
         getServer().getMessenger().registerOutgoingPluginChannel(this, "queue:join");
         this.getCommand("joinqueue").setExecutor(new JoinQueueCommand());
         this.getCommand("beta").setExecutor(new BetaCommand());
-        this.getCommand("art").setExecutor(new ArtCommand());
         this.getCommand("premium").setExecutor(new PremiumCommand());
+        this.getCommand("towny").setExecutor(new TownyCommand());
+
+        Bukkit.getServer().getScheduler().scheduleSyncRepeatingTask(this, () ->
+        {
+            for (Entry <UUID,Long> currentPlayer : awaitingBetaConfirmation.entrySet()) {
+                if (System.currentTimeMillis() > currentPlayer.getValue()) //Confirmation is expired
+                {
+                    awaitingBetaConfirmation.remove(currentPlayer.getKey());
+                    Bukkit.getPlayer(currentPlayer.getKey()).spigot().sendMessage(new TextComponent(ChatColor.RED + "Beta command confirmation timed out."));
+                }
+            }
+        }, 100, 100);
     }
 
-    private class BetaCommand implements CommandExecutor
+    private class TownyCommand implements CommandExecutor
     {
-        @Override
         public boolean onCommand(CommandSender sender, Command command, String label, String[] args)
         {
-            return getServer().dispatchCommand(sender, "joinqueue beta");
+            return getServer().dispatchCommand(sender, "joinqueue towny");
         }
     }
-
-    private class ArtCommand implements CommandExecutor
-    {
-        @Override
-        public boolean onCommand(CommandSender sender, Command command, String label, String[] args)
-        {
-            return getServer().dispatchCommand(sender, "joinqueue art");
-        }
-    }
-
     public static boolean executeCommand(String command)
     {
         return instance.getServer().dispatchCommand(instance.getServer().getConsoleSender(), command);

--- a/src/main/java/com/karlofduty/EMCTools/commands/BetaCommand.java
+++ b/src/main/java/com/karlofduty/EMCTools/commands/BetaCommand.java
@@ -1,0 +1,52 @@
+package com.karlofduty.EMCTools.commands;
+
+import com.karlofduty.EMCTools.EMCTools;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.ConsoleCommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+
+import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.api.chat.TextComponent;
+
+public class BetaCommand implements CommandExecutor, TabCompleter 
+{
+    public List<String> onTabComplete(CommandSender sender, Command command, String label, String[] args)
+    {
+        if (args.length == 1)
+            return Arrays.asList("-skipconfirmation");
+        else
+            return Collections.emptyList();
+    }
+
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args)
+    {
+        if (sender instanceof ConsoleCommandSender)
+        {
+            sender.sendMessage("§cCannot use this command as console.");
+            return true;
+        }
+
+        Player player = (Player) sender;
+        if (EMCTools.awaitingBetaConfirmation.containsKey(player.getUniqueId()) || (args.length > 0 && args[0].toLowerCase().equals("-skipconfirmation"))) // Player is accepting the confirmation.
+        {
+            Bukkit.getServer().dispatchCommand(sender, "joinqueue beta");
+            if (EMCTools.awaitingBetaConfirmation.containsKey(player.getUniqueId()))
+                EMCTools.awaitingBetaConfirmation.remove(player.getUniqueId());
+            return true;
+        }
+
+        EMCTools.awaitingBetaConfirmation.put(player.getUniqueId(), (System.currentTimeMillis() + 20 * 1000));
+        sender.spigot().sendMessage(new TextComponent(ChatColor.GREEN + "Run the /beta command again to be sent to the beta server."));
+        sender.spigot().sendMessage(new TextComponent(ChatColor.GREEN + "You will be sent to the beta server. Use the /towny command to re-queue for Towny."));
+        return true;
+    }
+}

--- a/src/main/java/com/karlofduty/EMCTools/commands/BetaCommand.java
+++ b/src/main/java/com/karlofduty/EMCTools/commands/BetaCommand.java
@@ -46,7 +46,7 @@ public class BetaCommand implements CommandExecutor, TabCompleter
 
         EMCTools.awaitingBetaConfirmation.put(player.getUniqueId(), (System.currentTimeMillis() + 20 * 1000));
         sender.spigot().sendMessage(new TextComponent(ChatColor.GREEN + "Run the /beta command again to be sent to the beta server."));
-        sender.spigot().sendMessage(new TextComponent(ChatColor.GREEN + "You will be sent to the beta server. Use the /towny command to re-queue for Towny."));
+        sender.spigot().sendMessage(new TextComponent(ChatColor.GREEN + "You will be sent to the beta server. Use /joinqueue towny to re-queue for Towny."));
         return true;
     }
 }

--- a/src/main/java/com/karlofduty/EMCTools/commands/PremiumCommand.java
+++ b/src/main/java/com/karlofduty/EMCTools/commands/PremiumCommand.java
@@ -1,15 +1,14 @@
 package com.karlofduty.EMCTools.commands;
 
 import net.md_5.bungee.api.chat.ClickEvent;
-import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.TextComponent;
+import net.md_5.bungee.api.chat.hover.content.Text;
+
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-
-import java.util.UUID;
 
 import static net.md_5.bungee.api.ChatColor.*;
 
@@ -24,26 +23,15 @@ public class PremiumCommand implements CommandExecutor
 			return false;
 		}
 
+		String message = "Click here to find out more about EarthMC premium!";
 		if(sender.hasPermission("group.premium"))
-		{
-			sender.sendMessage(new TextComponent(
-				new ComponentBuilder("Wow, thanks for supporting the server with your Premium subscription! You are amazing!")
-					.color(LIGHT_PURPLE)
-					.event(new ClickEvent(ClickEvent.Action.OPEN_URL,"https://store.earthmc.net/premiumcommand"))
-					.event(new HoverEvent(HoverEvent.Action.SHOW_TEXT, TextComponent.fromLegacyText(DARK_PURPLE + "Open EarthMC.net Premium information.")))
-					.create()
-			));
-		}
-		else
-		{
-			sender.sendMessage(new TextComponent(
-				new ComponentBuilder("Click here to find out more about EarthMC premium!")
-					.color(LIGHT_PURPLE)
-					.event(new ClickEvent(ClickEvent.Action.OPEN_URL,"https://store.earthmc.net/premiumcommand"))
-					.event(new HoverEvent(HoverEvent.Action.SHOW_TEXT, TextComponent.fromLegacyText(DARK_PURPLE + "Open EarthMC.net Premium information.")))
-					.create()
-			));
-		}
+			message = "Wow, thanks for supporting the server with your Premium subscription! You are amazing!";
+		
+		TextComponent premiumMessage = new TextComponent(LIGHT_PURPLE + message);
+		premiumMessage.setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL,"https://store.earthmc.net/premiumcommand"));
+		premiumMessage.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(DARK_PURPLE + "Open EarthMC.net Premium information.")));
+		
+		sender.spigot().sendMessage(premiumMessage);
 		return true;
 	}
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -17,9 +17,9 @@ commands:
   beta:
     description: Joins the beta server.
     usage: /beta
-  art:
-    description: Joins the art server.
-    usage: /art
   premium:
     description: Shows premium information.
     usage: /premium
+  towny:
+    description: Joins the towny server.
+    usage: /towny

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -20,6 +20,3 @@ commands:
   premium:
     description: Shows premium information.
     usage: /premium
-  towny:
-    description: Joins the towny server.
-    usage: /towny

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: EMCTools
 version: ${project.version}
 description: ${project.description}
-api-version: '1.13'
+api-version: '1.16'
 author: creatorfromhell, KarlofDuty
 website: http://karlofduty.com
 load: POSTWORLD


### PR DESCRIPTION
## Changes:
- Removed old /art command.
- Replaced deprecated methods in the premium command.
- Beta command now requires a confirmation, before actually sending players to the beta server.