### PR TITLE
Add /calculate command

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,12 +13,22 @@
             <id>papermc</id>
             <url>https://papermc.io/repo/repository/maven-public/</url>
         </repository>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
     </repositories>
     <dependencies>
         <dependency>
             <groupId>com.destroystokyo.paper</groupId>
             <artifactId>paper-api</artifactId>
             <version>1.16.5-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.TownyAdvanced</groupId>
+            <artifactId>Towny</artifactId>
+            <version>0.96.7.11</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/karlofduty/EMCTools/EMCTools.java
+++ b/src/main/java/com/karlofduty/EMCTools/EMCTools.java
@@ -7,6 +7,7 @@ import java.util.Map.Entry;
 
 import com.karlofduty.EMCTools.commands.BetaCommand;
 import com.karlofduty.EMCTools.commands.JoinQueueCommand;
+import com.karlofduty.EMCTools.commands.CalcCommand;
 import com.karlofduty.EMCTools.commands.PremiumCommand;
 
 import org.bukkit.Bukkit;
@@ -28,6 +29,7 @@ public class EMCTools extends JavaPlugin
         this.getCommand("joinqueue").setExecutor(new JoinQueueCommand());
         this.getCommand("beta").setExecutor(new BetaCommand());
         this.getCommand("premium").setExecutor(new PremiumCommand());
+        this.getCommand("calculate").setExecutor(new CalcCommand());
 
         Bukkit.getServer().getScheduler().scheduleSyncRepeatingTask(this, () ->
         {

--- a/src/main/java/com/karlofduty/EMCTools/commands/CalcCommand.java
+++ b/src/main/java/com/karlofduty/EMCTools/commands/CalcCommand.java
@@ -40,7 +40,7 @@ public class CalcCommand implements CommandExecutor
 			float sum = 0;
 			Chest chestblock = (Chest) block;
 			Inventory inv = chestblock.getBlockInventory();
-			sum += inv.all(Material.GOLDEN_INGOT).size();
+			sum += inv.all(Material.GOLD_INGOT).size();
 			sum += inv.all(Material.GOLD_BLOCK).size() * 9;
 			sum += inv.all(Material.BEACON).size() * 60;
 			sum += inv.all(Material.GOLDEN_APPLE).size() * 8;
@@ -55,14 +55,14 @@ public class CalcCommand implements CommandExecutor
 			sum += inv.all(Material.ENCHANTED_GOLDEN_APPLE).size() * 576;
 			sum += inv.all(Material.TURTLE_HELMET).size() * 8;
 			sum += inv.all(Material.BELL).size() * 54;
-			sum += inv.all(Material.DRAGON_SKULL).size() * 800;
+			sum += inv.all(Material.DRAGON_HEAD).size() * 800;
 			sum += inv.all(Material.NETHERITE_HELMET).size() * 10;
 			sum += inv.all(Material.NETHERITE_CHESTPLATE).size() * 10;
 			sum += inv.all(Material.NETHERITE_LEGGINGS).size() * 10;
 			sum += inv.all(Material.NETHERITE_BOOTS).size() * 10;
 			for (ItemStack item : inv.getContents())
 			{
-				if (item.hasEnchant(Enchantment.MENDING)) sum += 35;
+				if (item.containsEnchantment(Enchantment.MENDING)) sum += 35;
 				if (item.getEnchantmentLevel(Enchantment.PROTECTION_EXPLOSIONS) == 5) sum += 310;
 				if (item.getEnchantmentLevel(Enchantment.THORNS) == 5) sum += 1152;
 				if (item.getItemMeta() instanceof EnchantmentStorageMeta) 

--- a/src/main/java/com/karlofduty/EMCTools/commands/CalcCommand.java
+++ b/src/main/java/com/karlofduty/EMCTools/commands/CalcCommand.java
@@ -1,0 +1,84 @@
+package com.karlofduty.EMCTools.commands;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import com.palmergames.bukkit.towny.utils.PlayerCacheUtil;
+import com.palmergames.bukkit.towny.object.TownyPermission.ActionType;
+import org.bukkit.block.Block;
+import org.bukkit.Material;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.BlockInventoryHolder;
+import org.bukkit.block.Chest;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.meta.EnchantmentStorageMeta;
+
+import static net.md_5.bungee.api.ChatColor.*;
+
+public class CalcCommand implements CommandExecutor
+{
+	@Override
+	public boolean onCommand(CommandSender sender, Command command, String label, String[] args)
+	{
+		if (!(sender instanceof Player))
+		{
+			sender.sendMessage("§CCannot use this command as console.");
+			return true;
+		}
+		
+		Player player = (Player) sender;
+		Block block = player.getTargetBlock(4);
+		if (!PlayerCacheUtil.getCachePermission(player, block.getLocation(), block.getType(), TownyPermission.ActionType.SWITCH))
+		{
+			sender.sendMessage("§CCannot use this command without permission.");
+			return true;
+		}
+		if (block instanceof BlockInventoryHolder)
+		{
+			float sum = 0;
+			Chest chestblock = (Chest) block;
+			Inventory inv = chestblock.getBlockInventory();
+			sum += inv.all(Material.GOLDEN_INGOT).size();
+			sum += inv.all(Material.GOLD_BLOCK).size() * 9;
+			sum += inv.all(Material.BEACON).size() * 60;
+			sum += inv.all(Material.GOLDEN_APPLE).size() * 8;
+			sum += inv.all(Material.DIAMOND_BLOCK).size() * 0.15;
+			sum += inv.all(Material.NETHERITE_INGOT).size() * 10;
+			sum += inv.all(Material.NETHERITE_BLOCK).size() * 90;
+			sum += inv.all(Material.TRIDENT).size() * 1000;
+			sum += inv.all(Material.TOTEM_OF_UNDYING).size() * 300;
+			sum += inv.all(Material.SPAWNER).size() * 30;
+			sum += inv.all(Material.NETHER_STAR).size() * 120;
+			sum += inv.all(Material.WITHER_SKELETON_SKULL).size() * 40;
+			sum += inv.all(Material.ENCHANTED_GOLDEN_APPLE).size() * 576;
+			sum += inv.all(Material.TURTLE_HELMET).size() * 8;
+			sum += inv.all(Material.BELL).size() * 54;
+			sum += inv.all(Material.DRAGON_SKULL).size() * 800;
+			sum += inv.all(Material.NETHERITE_HELMET).size() * 10;
+			sum += inv.all(Material.NETHERITE_CHESTPLATE).size() * 10;
+			sum += inv.all(Material.NETHERITE_LEGGINGS).size() * 10;
+			sum += inv.all(Material.NETHERITE_BOOTS).size() * 10;
+			for (ItemStack item : inv.getContents())
+			{
+				if (item.hasEnchant(Enchantment.MENDING)) sum += 35;
+				if (item.getEnchantmentLevel(Enchantment.PROTECTION_EXPLOSIONS) == 5) sum += 310;
+				if (item.getEnchantmentLevel(Enchantment.THORNS) == 5) sum += 1152;
+				if (item.getItemMeta() instanceof EnchantmentStorageMeta) 
+				{
+					EnchantmentStorageMeta meta = (EnchantmentStorageMeta) item.getItemMeta();
+					if (meta.getStoredEnchants().containsKey(Enchantment.MENDING)) sum += 35;
+				}
+			}
+			player.sendMessage("§2This chest contains a sum of §6§LG" + sum + "§7.");
+			return true;
+		
+		} else {
+			sender.sendMessage("§CTarget any container to process.");
+			return true;
+		}
+	
+		return true;
+	}
+}

--- a/src/main/java/com/karlofduty/EMCTools/commands/CalcCommand.java
+++ b/src/main/java/com/karlofduty/EMCTools/commands/CalcCommand.java
@@ -7,71 +7,69 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import com.palmergames.bukkit.towny.utils.PlayerCacheUtil;
 import org.bukkit.block.Block;
-import org.bukkit.Material;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.BlockInventoryHolder;
-import org.bukkit.block.Chest;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
 
-public class CalcCommand implements CommandExecutor
-{
+public class CalcCommand implements CommandExecutor {
 	@Override
-	public boolean onCommand(CommandSender sender, Command command, String label, String[] args)
-	{
-		if (!(sender instanceof Player))
-		{
+	public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+		if (!(sender instanceof Player)) {
 			sender.sendMessage("§CCannot use this command as console.");
 			return true;
 		}
-		
+
 		Player player = (Player) sender;
-		Block block = player.getTargetBlock(4);
+		Block block = player.getTargetBlock(5);
 		if (block == null) return true;
-		if (!PlayerCacheUtil.getCachePermission(player, block.getLocation(), block.getType(), TownyPermission.ActionType.SWITCH))
-		{
+		if (!PlayerCacheUtil.getCachePermission(player, block.getLocation(), block.getType(), TownyPermission.ActionType.SWITCH)) {
 			sender.sendMessage("§CCannot use this command without permission.");
 			return true;
 		}
-		if (block instanceof BlockInventoryHolder)
-		{
+		if (block.getState() instanceof BlockInventoryHolder) {
 			float sum = 0;
-			Chest chestblock = (Chest) block;
-			Inventory inv = chestblock.getBlockInventory();
-			sum += inv.all(Material.GOLD_INGOT).size();
-			sum += inv.all(Material.GOLD_BLOCK).size() * 9;
-			sum += inv.all(Material.BEACON).size() * 60;
-			sum += inv.all(Material.GOLDEN_APPLE).size() * 8;
-			sum += inv.all(Material.DIAMOND_BLOCK).size() * 0.15;
-			sum += inv.all(Material.NETHERITE_INGOT).size() * 10;
-			sum += inv.all(Material.NETHERITE_BLOCK).size() * 90;
-			sum += inv.all(Material.TRIDENT).size() * 1000;
-			sum += inv.all(Material.TOTEM_OF_UNDYING).size() * 300;
-			sum += inv.all(Material.SPAWNER).size() * 30;
-			sum += inv.all(Material.NETHER_STAR).size() * 120;
-			sum += inv.all(Material.WITHER_SKELETON_SKULL).size() * 40;
-			sum += inv.all(Material.ENCHANTED_GOLDEN_APPLE).size() * 576;
-			sum += inv.all(Material.TURTLE_HELMET).size() * 8;
-			sum += inv.all(Material.BELL).size() * 54;
-			sum += inv.all(Material.DRAGON_HEAD).size() * 800;
-			sum += inv.all(Material.NETHERITE_HELMET).size() * 10;
-			sum += inv.all(Material.NETHERITE_CHESTPLATE).size() * 10;
-			sum += inv.all(Material.NETHERITE_LEGGINGS).size() * 10;
-			sum += inv.all(Material.NETHERITE_BOOTS).size() * 10;
-			for (ItemStack item : inv.getContents())
-			{
+			BlockInventoryHolder invhold = (BlockInventoryHolder) block.getState();
+			Inventory inv = invhold.getInventory();
+
+			for (ItemStack item : inv.getContents()) {
 				if (item == null) continue;
+				int amount = item.getAmount();
+
+				switch (item.getType()) {
+					case GOLD_INGOT: sum += amount; break;
+					case GOLD_BLOCK: sum += amount * 9; break;
+					case BEACON: sum += amount * 60; break;
+					case GOLDEN_APPLE: sum += amount * 8; break;
+					case DIAMOND_BLOCK: sum += amount * 0.15; break;
+					case NETHERITE_INGOT: sum += amount * 10; break;
+					case NETHERITE_BLOCK: sum += amount * 90; break;
+					case TRIDENT: sum += 1000; break;
+					case TOTEM_OF_UNDYING: sum += 300; break;
+					case TURTLE_HELMET: sum += 8; break;
+					case SPAWNER: sum += amount * 30; break;
+					case NETHER_STAR: sum += amount * 120; break;
+					case WITHER_SKELETON_SKULL: sum += amount * 40; break;
+					case ENCHANTED_GOLDEN_APPLE: sum += amount * 576; break;
+					case BELL: sum += amount * 54; break;
+					case DRAGON_HEAD: sum += amount * 800; break;
+					case NETHERITE_HELMET:
+					case NETHERITE_CHESTPLATE:
+					case NETHERITE_LEGGINGS:
+					case NETHERITE_BOOTS:
+						sum += 10; break;
+				}
+
 				if (item.containsEnchantment(Enchantment.MENDING)) sum += 35;
 				if (item.getEnchantmentLevel(Enchantment.PROTECTION_EXPLOSIONS) == 5) sum += 310;
 				if (item.getEnchantmentLevel(Enchantment.THORNS) == 5) sum += 1152;
-				if (item.getItemMeta() instanceof EnchantmentStorageMeta) 
-				{
+				if (item.getItemMeta() instanceof EnchantmentStorageMeta) {
 					EnchantmentStorageMeta meta = (EnchantmentStorageMeta) item.getItemMeta();
 					if (meta.getStoredEnchants().containsKey(Enchantment.MENDING)) sum += 35;
 				}
 			}
-			player.sendMessage("§2This chest contains a sum of §6§LG" + sum + "§7.");
+			player.sendMessage("§2This chest contains a sum of §6§LG" + Math.round(sum) + "§2.");
 			return true;
 		
 		} else {

--- a/src/main/java/com/karlofduty/EMCTools/commands/CalcCommand.java
+++ b/src/main/java/com/karlofduty/EMCTools/commands/CalcCommand.java
@@ -1,11 +1,11 @@
 package com.karlofduty.EMCTools.commands;
 
+import com.palmergames.bukkit.towny.object.TownyPermission;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import com.palmergames.bukkit.towny.utils.PlayerCacheUtil;
-import com.palmergames.bukkit.towny.object.TownyPermission.ActionType;
 import org.bukkit.block.Block;
 import org.bukkit.Material;
 import org.bukkit.inventory.Inventory;
@@ -14,8 +14,6 @@ import org.bukkit.block.Chest;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
-
-import static net.md_5.bungee.api.ChatColor.*;
 
 public class CalcCommand implements CommandExecutor
 {
@@ -30,6 +28,7 @@ public class CalcCommand implements CommandExecutor
 		
 		Player player = (Player) sender;
 		Block block = player.getTargetBlock(4);
+		if (block == null) return true;
 		if (!PlayerCacheUtil.getCachePermission(player, block.getLocation(), block.getType(), TownyPermission.ActionType.SWITCH))
 		{
 			sender.sendMessage("§CCannot use this command without permission.");
@@ -62,6 +61,7 @@ public class CalcCommand implements CommandExecutor
 			sum += inv.all(Material.NETHERITE_BOOTS).size() * 10;
 			for (ItemStack item : inv.getContents())
 			{
+				if (item == null) continue;
 				if (item.containsEnchantment(Enchantment.MENDING)) sum += 35;
 				if (item.getEnchantmentLevel(Enchantment.PROTECTION_EXPLOSIONS) == 5) sum += 310;
 				if (item.getEnchantmentLevel(Enchantment.THORNS) == 5) sum += 1152;
@@ -78,7 +78,5 @@ public class CalcCommand implements CommandExecutor
 			sender.sendMessage("§CTarget any container to process.");
 			return true;
 		}
-	
-		return true;
 	}
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,6 +6,8 @@ author: creatorfromhell, KarlofDuty
 website: http://karlofduty.com
 load: POSTWORLD
 main: com.karlofduty.EMCTools.EMCTools
+depend:
+  - Towny
 permissions:
   emc.joinqueue:
     description: Lets a player join the bungeecord queue.

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -20,3 +20,6 @@ commands:
   premium:
     description: Shows premium information.
     usage: /premium
+  calculate:
+    description: Calculates an approx. value of container. (July 2021 economy)
+    usage: /calculate


### PR DESCRIPTION
This command allows to calculate an approximate worth storaged in container, but it includes only uncommon/rare/epic+ items. Why not adding it :trollface:. player must target any container and then type /calculate, they must also have switch permissions at location of targeted block. 

problems with economy: it would be updated probably by me each some time, or mod+ can execute a command which updates prices